### PR TITLE
break intentionally

### DIFF
--- a/docs/blog/2017-02-21-1-0-progress-update-where-came-from-where-going/index.md
+++ b/docs/blog/2017-02-21-1-0-progress-update-where-came-from-where-going/index.md
@@ -357,3 +357,4 @@ If you're interested in contributing, please join the
 [Gatsby Discord](https://gatsby.app/discord), check out the
 [issues](https://github.com/gatsbyjs/gatsby/issues), and help bikeshed on names
 and APIs and other ideas.
+


### PR DESCRIPTION
This will serve as a pull request to show how CI is broken with the new prettier changes.

See [TravisCI](https://travis-ci.org/DSchau/prettier-check-repro/builds/484511427?utm_source=github_status&utm_medium=notification) and [CircleCI](https://circleci.com/gh/DSchau/prettier-check-repro/2?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link)

The console output clogs with _all_ of the files that are checked and doesn't (only) display the broken ones.